### PR TITLE
Various fixes for stacked items

### DIFF
--- a/src/main/java/online/connlost/allstackable/mixin/MixinAnvilScreenHandler.java
+++ b/src/main/java/online/connlost/allstackable/mixin/MixinAnvilScreenHandler.java
@@ -1,0 +1,63 @@
+package online.connlost.allstackable.mixin;
+
+import online.connlost.allstackable.util.ItemsHelper;
+import net.minecraft.inventory.Inventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.screen.AnvilScreenHandler;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(AnvilScreenHandler.class)
+public class MixinAnvilScreenHandler {
+    /**
+    * 
+    * Decrement the input stacks by one instead of blindly setting them
+    * to an empty stack.
+    * This prevents entire stacks from being deleted at a time.
+    * 
+    **/
+    @Redirect(method = "onTakeOutput", at = @At(value = "INVOKE", target = "Lnet/minecraft/inventory/Inventory;setStack(ILnet/minecraft/item/ItemStack;)V"))
+    private void decrementOne(Inventory inventory, int slot, ItemStack stack) {
+        if (ItemsHelper.isModified(stack) && stack.getCount() > 1) { 
+            if(stack.isEmpty()) {
+                stack = inventory.getStack(slot);
+                stack.decrement(1);
+            }
+        }
+        
+        inventory.setStack(slot, stack);
+    }
+    
+    /**
+    * 
+    * Update the output every time the output is taken in addition to
+    * updating when the inputs are changed. 
+    * This allows the output to be taken multiple times without needing
+    * to change an input in between every take.
+    * 
+    **/
+    @Inject(method = "onTakeOutput", at = @At("RETURN"))
+    private void updateAfterTaking(CallbackInfo ci) {
+        ((AnvilScreenHandler)(Object)this).updateResult();
+    }
+    
+    /**
+    * 
+    * Only output a single item at a time.
+    * This prevents entire stacks from being repaired/enchanted at a time.
+    * 
+    **/
+    @Redirect(method = "updateResult", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;copy()Lnet/minecraft/item/ItemStack;", ordinal = 0))
+    public ItemStack copyOne(ItemStack itemStack) {
+        ItemStack stack = itemStack.copy();
+        if (ItemsHelper.isModified(stack) && stack.getCount() > 1) { 
+            if(!stack.isEmpty()) {
+                stack.setCount(1);
+            }
+        }
+        return stack;
+    }
+}

--- a/src/main/java/online/connlost/allstackable/mixin/MixinAnvilScreenHandler.java
+++ b/src/main/java/online/connlost/allstackable/mixin/MixinAnvilScreenHandler.java
@@ -21,9 +21,10 @@ public class MixinAnvilScreenHandler {
     **/
     @Redirect(method = "onTakeOutput", at = @At(value = "INVOKE", target = "Lnet/minecraft/inventory/Inventory;setStack(ILnet/minecraft/item/ItemStack;)V"))
     private void decrementOne(Inventory inventory, int slot, ItemStack stack) {
-        if (ItemsHelper.isModified(stack) && stack.getCount() > 1) { 
+        ItemStack originalStack = inventory.getStack(slot);
+        if (ItemsHelper.isModified(originalStack) && originalStack.getCount() > 1) {
             if(stack.isEmpty()) {
-                stack = inventory.getStack(slot);
+                stack = originalStack;
                 stack.decrement(1);
             }
         }

--- a/src/main/java/online/connlost/allstackable/mixin/MixinDispenserBehavior.java
+++ b/src/main/java/online/connlost/allstackable/mixin/MixinDispenserBehavior.java
@@ -1,0 +1,48 @@
+package online.connlost.allstackable.mixin;
+
+import online.connlost.allstackable.util.ItemsHelper;
+import net.minecraft.block.dispenser.ItemDispenserBehavior;
+import net.minecraft.block.entity.DispenserBlockEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.util.math.BlockPointer;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(targets = "net/minecraft/block/dispenser/DispenserBehavior$8")
+public class MixinDispenserBehavior {
+    @Shadow
+	@Final
+    private ItemDispenserBehavior fallbackBehavior;
+    
+    /**
+    * 
+    * Remove one bucket at a time instead of deleting the entire stack.
+    * If there's no room for the empty bucket in the dispenser, have it be
+    * dispensed instead.
+    * This prevents entire stacks from being deleted at a time.
+    * 
+    **/
+    @Inject(
+        method = "Lnet/minecraft/block/dispenser/ItemDispenserBehavior;dispenseSilently(Lnet/minecraft/util/math/BlockPointer;Lnet/minecraft/item/ItemStack;)Lnet/minecraft/item/ItemStack;",
+        at = @At(
+            value = "INVOKE", 
+            target = "Lnet/minecraft/item/FluidModificationItem;onEmptied(Lnet/minecraft/entity/player/PlayerEntity;Lnet/minecraft/world/World;Lnet/minecraft/item/ItemStack;Lnet/minecraft/util/math/BlockPos;)V",
+            shift = At.Shift.AFTER
+            ),
+        cancellable = true)
+    public void dispenseOne(BlockPointer pointer, ItemStack stack, CallbackInfoReturnable<ItemStack> cir) {
+        if (ItemsHelper.isModified(stack) && stack.getCount() > 1) {
+            ItemStack newStack = stack.copy();
+            newStack.decrement(1);
+            if (((DispenserBlockEntity)pointer.getBlockEntity()).addToFirstFreeSlot(Items.BUCKET.getDefaultStack()) < 0) {
+                this.fallbackBehavior.dispense(pointer, Items.BUCKET.getDefaultStack());
+            }
+            cir.setReturnValue(newStack);
+        }
+    }
+}

--- a/src/main/java/online/connlost/allstackable/mixin/MixinHorseScreenHandler.java
+++ b/src/main/java/online/connlost/allstackable/mixin/MixinHorseScreenHandler.java
@@ -1,0 +1,17 @@
+package online.connlost.allstackable.mixin;
+
+import net.minecraft.inventory.Inventory;
+import net.minecraft.screen.slot.Slot;
+import org.spongepowered.asm.mixin.Mixin;
+
+@Mixin(targets = "net/minecraft/screen/HorseScreenHandler$1")
+public class MixinHorseScreenHandler extends Slot {
+    public MixinHorseScreenHandler(Inventory inventory, int index, int x, int y) {
+        super(inventory, index, x, y);
+    }
+
+    @Override
+    public int getMaxItemCount() {
+        return 1;
+    }
+}

--- a/src/main/java/online/connlost/allstackable/mixin/MixinJukeboxBlockEntity.java
+++ b/src/main/java/online/connlost/allstackable/mixin/MixinJukeboxBlockEntity.java
@@ -1,0 +1,28 @@
+package online.connlost.allstackable.mixin;
+
+import online.connlost.allstackable.util.ItemsHelper;
+import net.minecraft.block.entity.JukeboxBlockEntity;
+import net.minecraft.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+@Mixin(JukeboxBlockEntity.class)
+public class MixinJukeboxBlockEntity {
+    
+    /**
+    * 
+    * Only store one record instead of the full stack, since that's what 
+    * MusicDiscItem assumes.
+    * This prevents item duplication where MusicDiscItem decrements the player's
+    * stack by 1, but the Jukebox stores and drops the full stack instead.
+    * 
+    **/
+    @ModifyVariable(method = "setRecord", at = @At("HEAD"))
+    private ItemStack setRecord(ItemStack stack) {
+        if (ItemsHelper.isModified(stack) && stack.getCount() > 1) { 
+            stack.setCount(1);
+        }
+        return stack;
+    }
+}

--- a/src/main/java/online/connlost/allstackable/mixin/MixinServerPlayNetworkHandler.java
+++ b/src/main/java/online/connlost/allstackable/mixin/MixinServerPlayNetworkHandler.java
@@ -1,0 +1,34 @@
+package online.connlost.allstackable.mixin;
+
+import online.connlost.allstackable.util.ItemsHelper;
+import net.minecraft.item.ItemStack;
+import net.minecraft.server.filter.TextStream;
+import net.minecraft.server.network.ServerPlayNetworkHandler;
+import net.minecraft.server.network.ServerPlayerEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+import java.util.List;
+
+@Mixin(ServerPlayNetworkHandler.class)
+public class MixinServerPlayNetworkHandler {
+    @Shadow 
+    public ServerPlayerEntity player;
+    
+    /**
+    * 
+    * Set the size of the new signed books to the size of the old writable books
+    * instead of only making one new signed book regardless of the stack size
+    * This prevents unexpected item deletion.
+    * 
+    **/
+    @ModifyVariable(method = "addBook", at = @At("STORE"), ordinal = 1)
+    public ItemStack fixSignedBookCount(ItemStack itemStack2, TextStream.Message title, List<TextStream.Message> pages, int slotId) {
+        if (ItemsHelper.isModified(itemStack2)) { 
+            itemStack2.setCount(player.getInventory().getStack(slotId).getCount());
+        }
+        return itemStack2;
+    }
+}

--- a/src/main/java/online/connlost/allstackable/mixin/MixinServerPlayNetworkHandler.java
+++ b/src/main/java/online/connlost/allstackable/mixin/MixinServerPlayNetworkHandler.java
@@ -8,27 +8,56 @@ import net.minecraft.server.network.ServerPlayerEntity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.util.List;
 
 @Mixin(ServerPlayNetworkHandler.class)
 public class MixinServerPlayNetworkHandler {
-    @Shadow 
+    @Shadow
     public ServerPlayerEntity player;
-    
+
     /**
-    * 
+    *
     * Set the size of the new signed books to the size of the old writable books
-    * instead of only making one new signed book regardless of the stack size
+    * instead of only making one new signed book regardless of the stack size.
     * This prevents unexpected item deletion.
-    * 
+    *
     **/
     @ModifyVariable(method = "addBook", at = @At("STORE"), ordinal = 1)
     public ItemStack fixSignedBookCount(ItemStack itemStack2, TextStream.Message title, List<TextStream.Message> pages, int slotId) {
-        if (ItemsHelper.isModified(itemStack2)) { 
-            itemStack2.setCount(player.getInventory().getStack(slotId).getCount());
+        ItemStack originalStack = player.getInventory().getStack(slotId);
+        if (ItemsHelper.isModified(originalStack)) {
+            itemStack2.setCount(originalStack.getCount());
         }
         return itemStack2;
+    }
+
+    /**
+    *
+    * Split the written book into several stacks if it is over its maximum
+    * stack count. This will occur whenever the writable book stack count is
+    * greater than the written book's maximum stack count.
+    *
+    **/
+    @Inject(method = "addBook", at = @At("RETURN"))
+    public void fixSignedBookOverCount(TextStream.Message title, List<TextStream.Message> pages, int slotId, CallbackInfo ci) {
+        ItemStack itemStack2 = player.getInventory().getStack(slotId);
+        if (ItemsHelper.isModified(itemStack2) && (itemStack2.getCount() > itemStack2.getMaxCount())) {
+            ItemStack splitStack = itemStack2.copy();
+            int count = itemStack2.getCount() % itemStack2.getMaxCount();
+            splitStack.setCount(count);
+            itemStack2.decrement(count);
+            ItemsHelper.insertNewItem(player, splitStack);
+            while(itemStack2.getCount() > itemStack2.getMaxCount()) {
+                splitStack = itemStack2.copy();
+                count = itemStack2.getMaxCount();
+                splitStack.setCount(count);
+                itemStack2.decrement(count);
+                ItemsHelper.insertNewItem(player, splitStack);
+            }
+        }
     }
 }

--- a/src/main/resources/allstackable.mixins.json
+++ b/src/main/resources/allstackable.mixins.json
@@ -15,6 +15,11 @@
     "MixinCauldronBlock",
     "MixinAxolotlEntity",
     "MixinAbstractFurnaceBlockEntity",
+    "MixinAnvilScreenHandler",
+    "MixinDispenserBehavior",
+    "MixinHorseScreenHandler",
+    "MixinServerPlayNetworkHandler",
+    "MixinJukeboxBlockEntity",
     "AccessorFurnaceInventory"
   ],
   "client": [


### PR DESCRIPTION
All inspired by [Lenient Stack Size](https://github.com/ZoeyTheEgoist/FabricMods/tree/main/LenientStackSize) which has a [CC0 1.0 Universal License](https://github.com/ZoeyTheEgoist/FabricMods/blob/main/LenientStackSize/LICENSE).

Game version: 1.18.1

MixinAnvilScreenHandler
-  fix using stacks of enchanted books, and repairing stacks of items

MixinDispenserBehavior
-  fix entire stacks of buckets being replaced by a single bucket

MixinHorseScreenHandler
-  fix entire stacks being damaged at a time

MixinServerPlayNetworkHandler
-  fix entire stack of book and quill's being replaced with a single written book when signed

MixinJukeboxBlockEntity
-  fix using stack of discs on jukebox resulting in dupes. player stack goes down by one, but the jukebox stores and drops the full stack