### PR TITLE
Fixed using buckets, crafting not stacking, and items in containers not stacking after re-entering the game

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs=-Xmx1G
 org.gradle.parallel=true
 
 # Fabric
-loader_version=0.16.5
+loader_version=0.16.10
 yarn_mappings=1.21+build.9
 minecraft_version=1.21
 fabric_version=0.102.0+1.21

--- a/src/main/java/online/connlost/allstackable/AllStackable.java
+++ b/src/main/java/online/connlost/allstackable/AllStackable.java
@@ -1,23 +1,35 @@
 package online.connlost.allstackable;
 
+import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
+import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.WorldSavePath;
+import net.minecraft.world.level.storage.LevelStorage;
 import online.connlost.allstackable.server.Server;
 import online.connlost.allstackable.server.command.StackSizeCommand;
+import online.connlost.allstackable.server.config.ConfigManager;
 import online.connlost.allstackable.util.ByteArrayPayload;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 
-public class AllStackable implements ModInitializer {
-	public static final Logger LOGGER = LogManager.getLogger();
+import java.io.File;
+import java.nio.file.Path;
 
-	@Override
-	public void onInitialize() {
-		PayloadTypeRegistry.playS2C().register(ByteArrayPayload.ID, ByteArrayPayload.CODEC);
-		LOGGER.info("[All Stackable] Start loading!");
-		StackSizeCommand.register();
-		LOGGER.info("[All Stackable] Command registered.");
-		ServerLifecycleEvents.SERVER_STARTED.register(Server::onServerLoaded);
-	}
+import static online.connlost.allstackable.server.Server.config_manager;
+
+public class AllStackable implements ModInitializer{
+    public static final Logger LOGGER = LogManager.getLogger();
+
+    @Override
+    public void onInitialize() {
+        PayloadTypeRegistry.playS2C().register(ByteArrayPayload.ID, ByteArrayPayload.CODEC);
+        LOGGER.info("[All Stackable] Start loading!");
+        StackSizeCommand.register();
+        LOGGER.info("[All Stackable] Command registered.");
+        ServerLifecycleEvents.SERVER_STARTING.register(Server::onServerLoaded);
+		ServerLifecycleEvents.SERVER_STARTED.register((minecraftServer) -> config_manager.sandConfig2Player());
+    }
 }

--- a/src/main/java/online/connlost/allstackable/AllStackable.java
+++ b/src/main/java/online/connlost/allstackable/AllStackable.java
@@ -1,22 +1,13 @@
 package online.connlost.allstackable;
 
-import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
-import net.fabricmc.loader.api.FabricLoader;
-import net.minecraft.server.MinecraftServer;
-import net.minecraft.util.WorldSavePath;
-import net.minecraft.world.level.storage.LevelStorage;
 import online.connlost.allstackable.server.Server;
 import online.connlost.allstackable.server.command.StackSizeCommand;
-import online.connlost.allstackable.server.config.ConfigManager;
 import online.connlost.allstackable.util.ByteArrayPayload;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import net.fabricmc.api.ModInitializer;
-import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
-
-import java.io.File;
-import java.nio.file.Path;
 
 import static online.connlost.allstackable.server.Server.config_manager;
 

--- a/src/main/java/online/connlost/allstackable/mixin/MixinBucketItem.java
+++ b/src/main/java/online/connlost/allstackable/mixin/MixinBucketItem.java
@@ -1,25 +1,27 @@
 package online.connlost.allstackable.mixin;
 
+
+import net.minecraft.screen.slot.SlotActionType;
 import online.connlost.allstackable.util.ItemsHelper;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.BucketItem;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(BucketItem.class)
 public class MixinBucketItem {
-
-    @Inject(method = "getEmptiedStack", at = @At(value = "HEAD"), cancellable = true)
-    private static void stackableBucket(ItemStack stack, PlayerEntity player, CallbackInfoReturnable<ItemStack> cir){
-            if (ItemsHelper.isModified(stack) && stack.getCount() > 1 && !player.getAbilities().creativeMode){
-                ItemsHelper.insertNewItem(player, new ItemStack(Items.BUCKET));
-                stack.decrement(1);
-                cir.setReturnValue(stack);
-            }
-    }
+//    @Inject(method = "getEmptiedStack", at = @At(value = "HEAD"), cancellable = true)
+//    private static void stackableBucket(ItemStack stack, PlayerEntity player, CallbackInfoReturnable<ItemStack> cir){
+//            if (ItemsHelper.isModified(stack) && stack.getCount() > 1 && !player.getAbilities().creativeMode){
+//                ItemsHelper.insertNewItem(player, new ItemStack(Items.BUCKET));
+//                stack.decrement(1);
+//                cir.setReturnValue(stack);
+//            }
+//    }
 
 }

--- a/src/main/java/online/connlost/allstackable/mixin/MixinLevelStorage.java
+++ b/src/main/java/online/connlost/allstackable/mixin/MixinLevelStorage.java
@@ -13,7 +13,7 @@ import static online.connlost.allstackable.server.Server.config_manager;
 @Mixin(LevelStorage.class)
 public class MixinLevelStorage {
     @WrapOperation(at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/storage/LevelStorage;resolve(Ljava/lang/String;)Ljava/nio/file/Path;"), method = "createSession")
-    private Path t1(LevelStorage instance, String name, Operation<Path> original){
+    private Path initConfig(LevelStorage instance, String name, Operation<Path> original){
         Path path = original.call(instance, name);
         config_manager.passConfigFile(path.resolve("allstackable-config.json").toFile());
         config_manager.setupConfig();

--- a/src/main/java/online/connlost/allstackable/mixin/MixinLevelStorage.java
+++ b/src/main/java/online/connlost/allstackable/mixin/MixinLevelStorage.java
@@ -1,0 +1,22 @@
+package online.connlost.allstackable.mixin;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import net.minecraft.world.level.storage.LevelStorage;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import java.nio.file.Path;
+import static online.connlost.allstackable.server.Server.config_manager;
+
+
+@Mixin(LevelStorage.class)
+public class MixinLevelStorage {
+    @WrapOperation(at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/storage/LevelStorage;resolve(Ljava/lang/String;)Ljava/nio/file/Path;"), method = "createSession")
+    private Path t1(LevelStorage instance, String name, Operation<Path> original){
+        Path path = original.call(instance, name);
+        config_manager.passConfigFile(path.resolve("allstackable-config.json").toFile());
+        config_manager.setupConfig();
+        return path;
+    }
+}

--- a/src/main/java/online/connlost/allstackable/server/Server.java
+++ b/src/main/java/online/connlost/allstackable/server/Server.java
@@ -1,14 +1,11 @@
 package online.connlost.allstackable.server;
 
-import net.fabricmc.loader.impl.game.minecraft.launchwrapper.FabricServerTweaker;
 import online.connlost.allstackable.server.config.ConfigManager;
 import online.connlost.allstackable.util.NetworkHelper;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayerEntity;
-import net.minecraft.util.WorldSavePath;
 import online.connlost.allstackable.AllStackable;
 
-import java.io.File;
 
 
 public class Server {

--- a/src/main/java/online/connlost/allstackable/server/Server.java
+++ b/src/main/java/online/connlost/allstackable/server/Server.java
@@ -1,5 +1,6 @@
 package online.connlost.allstackable.server;
 
+import net.fabricmc.loader.impl.game.minecraft.launchwrapper.FabricServerTweaker;
 import online.connlost.allstackable.server.config.ConfigManager;
 import online.connlost.allstackable.util.NetworkHelper;
 import net.minecraft.server.MinecraftServer;
@@ -7,20 +8,21 @@ import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.WorldSavePath;
 import online.connlost.allstackable.AllStackable;
 
+import java.io.File;
+
 
 public class Server {
     public static MinecraftServer minecraft_server;
     public static ConfigManager config_manager = ConfigManager.getConfigManager();
 
-    public static void onServerLoaded(MinecraftServer ms){
+    public static void onServerLoaded(MinecraftServer ms) {
         minecraft_server = ms;
-        config_manager.passConfigFile(minecraft_server.getSavePath(WorldSavePath.ROOT).resolve("allstackable-config.json").toFile());
+//        config_manager.passConfigFile(minecraft_server.getSavePath(WorldSavePath.ROOT).resolve("allstackable-config.json").toFile());
         config_manager.setupConfig();
         AllStackable.LOGGER.info("[All Stackable] Loaded!");
     }
 
-    public static void onPlayerJoin(ServerPlayerEntity player){
+    public static void onPlayerJoin(ServerPlayerEntity player) {
         NetworkHelper.sentConfigToPlayer(player, ConfigManager.getConfigManager().getSerializedConfig());
     }
-
 }

--- a/src/main/java/online/connlost/allstackable/server/config/ConfigManager.java
+++ b/src/main/java/online/connlost/allstackable/server/config/ConfigManager.java
@@ -16,7 +16,7 @@ import org.apache.commons.lang3.SerializationUtils;
 
 final public class ConfigManager {
     private static ConfigManager cm;
-    private File configFile;
+    public File configFile;
     private File globalConfigFile;
     private Gson gson;
     private ItemsHelper itemsHelper;
@@ -95,8 +95,10 @@ final public class ConfigManager {
     public void setupConfig() {
         loadConfig();
         itemsHelper.setCountByConfig(this.configList.get(0).entrySet(), true);
-        NetworkHelper.sentConfigToAll();
         AllStackable.LOGGER.info("[All Stackable] Config Loaded");
+    }
+    public void sandConfig2Player(){
+        NetworkHelper.sentConfigToAll();
     }
 
     public boolean restoreBackup() {

--- a/src/main/resources/allstackable.mixins.json
+++ b/src/main/resources/allstackable.mixins.json
@@ -1,28 +1,29 @@
 {
-	"required": true,
-	"package": "online.connlost.allstackable.mixin",
-	"compatibilityLevel": "JAVA_21",
-	"mixins": [
-		"MixinItem",
-		"MixinPlayerManager",
-		"MixinSuspiciousStewItem",
-		"MixinBucketItem",
-		"MixinItemStack",
-		"MixinPowderSnowBucketItem",
-		"MixinCauldronBlock",
-		"MixinAxolotlEntity",
-		"MixinAbstractFurnaceBlockEntity",
-		"MixinAnvilScreenHandler",
-		"MixinDispenserBehavior8",
-		"MixinDispenserBehavior9",
-		"MixinHorseScreenHandler",
-		"MixinServerPlayNetworkHandler",
-		"MixinJukeboxBlockEntity",
-		"AccessorFurnaceInventory",
-		"MixinPotionItem",
-		"MixinDispenserBlockEntity"
-	],
-	"injectors": {
-		"defaultRequire": 1
+  "required": true,
+  "package": "online.connlost.allstackable.mixin",
+  "compatibilityLevel": "JAVA_21",
+  "mixins": [
+    "AccessorFurnaceInventory",
+    "MixinAbstractFurnaceBlockEntity",
+    "MixinAnvilScreenHandler",
+    "MixinAxolotlEntity",
+    "MixinBucketItem",
+    "MixinCauldronBlock",
+    "MixinDispenserBehavior8",
+    "MixinDispenserBehavior9",
+    "MixinDispenserBlockEntity",
+    "MixinHorseScreenHandler",
+    "MixinItem",
+    "MixinItemStack",
+    "MixinJukeboxBlockEntity",
+    "MixinPlayerManager",
+    "MixinPotionItem",
+    "MixinPowderSnowBucketItem",
+    "MixinServerPlayNetworkHandler",
+    "MixinSuspiciousStewItem",
+    "MixinLevelStorage"
+  ],
+  "injectors": {
+    "defaultRequire": 1
 	}
 }


### PR DESCRIPTION
MixinBucketItem doesn't need it to do anything.
The components of the items in the container should be loaded before the server starts, while the crafting table needs to be sooner

MixinBucketItem 不需要它做任何事情。
容器中物品的组件应该在服务器启动之前加载，而合成表需要更早